### PR TITLE
Publish images to GitHub container registry automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "master"
+      
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add --update alpine-sdk linux-headers \
   && make -f make-linux.mk
 
 FROM alpine:3.13
-LABEL version="1.6.5"
 LABEL description="ZeroTier One docker image for Synology NAS"
 
 RUN apk add --update --no-cache libc6-compat libstdc++

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This container is originally based on [zyclonite/zerotier](https://hub.docker.co
 
 This is publised to the GitHub container registry at "ghcr.io/tjenkinson/zerotier-synology" using the following tags:
 
-- <major>.<minor>.<patch>
-- <major>.<minor>
-- <major>
+- `<major>.<minor>.<patch>`
+- `<major>.<minor>`
+- `<major>`
 
 E.g `docker pull ghcr.io/tjenkinson/zerotier-synology:1` for the latest from `v1`.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ This is publised to the GitHub container registry at "[ghcr.io/tjenkinson/zeroti
 - `<major>`
 
 E.g `docker pull ghcr.io/tjenkinson/zerotier-synology:1` for the latest from `v1`.
+
+
+## Versioning
+
+The versions of the image do not match the versions of ZeroTier itself.
+
+We respect the version bump of ZeroTier though, so a new minor version of ZeroTier would be at least a minor version here, and major would be major.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Alpine-based Docker image for ZeroTier on Synology
 
 This container is originally based on [zyclonite/zerotier](https://hub.docker.com/r/zyclonite/zerotier) but is maintained officially by the ZeroTier team.
 
-This is publised to the GitHub container registry at "ghcr.io/tjenkinson/zerotier-synology" using the following tags:
+This is publised to the GitHub container registry at "[ghcr.io/tjenkinson/zerotier-synology](https://github.com/tjenkinson/zerotier-synology/pkgs/container/zerotier-synology)" using the following tags:
 
 - `<major>.<minor>.<patch>`
 - `<major>.<minor>`

--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@ Alpine-based Docker image for ZeroTier on Synology
 =====
 
 This container is originally based on [zyclonite/zerotier](https://hub.docker.com/r/zyclonite/zerotier) but is maintained officially by the ZeroTier team.
+
+This is publised to the GitHub container registry at "ghcr.io/tjenkinson/zerotier-synology" using the following tags:
+
+- <major>.<minor>.<patch>
+- <major>.<minor>
+- <major>
+
+E.g `docker pull ghcr.io/tjenkinson/zerotier-synology:1` for the latest from `v1`.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Alpine-based Docker image for ZeroTier on Synology
 
 This container is originally based on [zyclonite/zerotier](https://hub.docker.com/r/zyclonite/zerotier) but is maintained officially by the ZeroTier team.
 
-This is publised to the GitHub container registry at "[ghcr.io/tjenkinson/zerotier-synology](https://github.com/tjenkinson/zerotier-synology/pkgs/container/zerotier-synology)" using the following tags:
+This is publised to the GitHub container registry at "[ghcr.io/zerotier/zerotier-synology](https://github.com/zerotier/zerotier-synology/pkgs/container/zerotier-synology)" using the following tags:
 
 - `<major>.<minor>.<patch>`
 - `<major>.<minor>`
 - `<major>`
 
-E.g `docker pull ghcr.io/tjenkinson/zerotier-synology:1` for the latest from `v1`.
+E.g `docker pull ghcr.io/zerotier/zerotier-synology:1` for the latest from `v1`.
 
 
 ## Versioning


### PR DESCRIPTION
This will publish images automatically to the registry when a tag is pushed. See the readme change for more info :)

Here's the result on my fork: https://github.com/tjenkinson/zerotier-synology/pkgs/container/zerotier-synology

closes #1 