### PR TITLE
Forgot to update version in labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --update alpine-sdk linux-headers \
   && make -f make-linux.mk
 
 FROM alpine:3.13
-LABEL version="1.6.5"
+LABEL version="1.6.6"
 LABEL description="ZeroTier One docker image for Synology NAS"
 
 RUN apk add --update --no-cache libc6-compat libstdc++


### PR DESCRIPTION
While bumping to 1.6.6, labels were not updated, so the published image had 1.6.5 in its labels despite of including zerotier 1.6.6

```
root@diskstation718:/volume1/docker/zerotier# docker inspect zerotier/zerotier-synology@sha256:181ebb28cb128387ea0e7ec97f0c0ca2ead40e9db9be1fb64c71f79dd7500259 | jq '.[0].Config.Labels'
{
  "description": "ZeroTier One docker image for Synology NAS",
  "version": "1.6.5"
}
root@diskstation718:/volume1/docker/zerotier# docker run --rm --entrypoint zerotier-one zerotier/zerotier-synology@sha256:181ebb28cb128387ea0e7ec97f0c0ca2ead40e9db9be1fb64c71f79dd7500259 -v
1.6.6
```